### PR TITLE
Feat (FE-96) and (FE-97)- Profile page functional implementation(Owner's Instance and Guest instance)

### DIFF
--- a/src/components/AskCards/AskCards.jsx
+++ b/src/components/AskCards/AskCards.jsx
@@ -60,7 +60,7 @@ function AskCards() {
 			setUsers(await getUser());
 			const fetchedReplies = fetchedQuestions.map(
 				async (fetchedQuestion) =>
-					await getTotalReplies(fetchedQuestion.question_id)
+					getTotalReplies(fetchedQuestion.question_id)
 			);
 
 			Promise.all([...fetchedReplies].reverse()).then((reply) =>

--- a/src/components/Asks/index.jsx
+++ b/src/components/Asks/index.jsx
@@ -127,7 +127,7 @@ function Asks() {
 				</div>
 			</section>
 			<h6 className={styles.reply}>{answer.content}</h6>
-			<section className={styles.cardFooter}></section>
+			<section className={styles.cardFooter} />
 		</div>
 	));
 

--- a/src/components/Section1/index.jsx
+++ b/src/components/Section1/index.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react';
 import axios from 'axios';
-import { useNavigate } from 'react-router-dom';
-
+import { useNavigate, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { AppContext } from '../../store/AppContext';
 import Section1 from './section1.module.css';
@@ -14,21 +13,21 @@ import clockIcon from '../../assets/profile-images/clock.png';
 
 function ProfileTopSection() {
 	const navigate = useNavigate();
-
+	const { pathname } = useLocation();
+	const user = pathname.slice(9);
 	const [info, setInfo] = useState({});
 	const { state } = useContext(AppContext);
 	const [isLoading, setIsLoading] = useState(false);
-
+	const [followers, setFollowers] = useState();
 	const handleEdit = () => {
 		navigate('/settings');
 	};
-
 	useEffect(() => {
 		const fetchUser = async () => {
 			try {
 				setIsLoading(true);
 				const data = await axios.get(
-					`https://api.devask.hng.tech/users/${state.user.userName}`,
+					`https://pacific-peak-54505.herokuapp.com/users/${user}`,
 					{
 						headers: {
 							Authorization: `Bearer ${state.token}`,
@@ -41,18 +40,34 @@ function ProfileTopSection() {
 				// console.error(err);
 			}
 		};
-
 		fetchUser();
-		// console.log(info)
 	}, [isLoading]);
-	console.log(state);
-
+	useEffect(() => {
+		const fetchFollowers = async () => {
+			try {
+				setIsLoading(true);
+				const res = await axios.get(
+					`https://pacific-peak-54505.herokuapp.com/following/followers/${state.user.userName}`,
+					{
+						headers: {
+							Authorization: `Bearer ${state.token}`,
+							'Content-Type': 'application/json',
+						},
+					}
+				);
+				setFollowers(res.followers.length);
+			} catch (err) {
+				// console.error(err);
+			}
+		};
+		fetchFollowers();
+		console.log(followers);
+	}, [isLoading]);
 	return (
 		<div className={Section1.profile__datawrapper}>
 			<div className={Section1.profile__datatxt}>
 				<div className={Section1.profile__imagewrapper}>
 					<img
-						// src={info.image_url} ||
 						src="https://www.pngitem.com/pimgs/m/581-5813504_avatar-dummy-png-transparent-png.png"
 						alt=""
 						className={Section1.profile__image}
@@ -88,25 +103,24 @@ function ProfileTopSection() {
 							{info.location}
 						</div>
 					</div>
-
 					<div className={Section1.profile__sociallinks}>
 						<div className={Section1.profile__link}>
 							<div className={Section1.profile__iconwrapper}>
 								<img src={link} alt="" className={Section1.profile__icon} />
 							</div>{' '}
-							{/* {info.links[0]} */}
+							{info.links}
 						</div>
 						<div className={Section1.profile__socials}>
 							<div className={Section1.profile__iconwrapper}>
 								<img src={github} alt="" className={Section1.profile__icon} />
 							</div>{' '}
-							{/* {info.links[1]} */}
+							{info.links}
 						</div>
 						<div className={Section1.profile__socials}>
 							<div className={Section1.profile__iconwrapper}>
 								<img src={twitter} alt="" className={Section1.profile__icon} />
 							</div>{' '}
-							{/* {info.links[2]} */}
+							{info.links}
 						</div>
 						<div className={Section1.profile__socials}>
 							<div className={Section1.profile__iconwrapper}>
@@ -121,10 +135,16 @@ function ProfileTopSection() {
 					</div>
 					<div className={Section1.profile__followingwallet}>
 						<div className={Section1.profile__link}>
-							<div className={Section1.profile__iconwrapper}>{}</div> Following
+							<div className={Section1.profile__iconwrapper}>
+								{info.following}
+							</div>{' '}
+							Following
 						</div>
 						<div className={Section1.profile__socials}>
-							<div className={Section1.profile__iconwrapper}>{}</div> Followers
+							<div className={Section1.profile__iconwrapper}>
+								{info.followers}
+							</div>{' '}
+							Followers
 						</div>
 						<div className={Section1.profile__socials}>
 							<div className={Section1.profile__iconwrapper}>
@@ -141,7 +161,7 @@ function ProfileTopSection() {
 			</div>
 			<div className={Section1.profile__btns}>
 				<div className={Section1.profile__btnwrapper}>
-					{info.user_id ? (
+					{state.user.username === user ? (
 						<button
 							className={Section1.btn2}
 							type="button"
@@ -159,9 +179,7 @@ function ProfileTopSection() {
 		</div>
 	);
 }
-
 export default ProfileTopSection;
-
 ProfileTopSection.propTypes = {
 	user: PropTypes.shape({
 		name: PropTypes.string.isRequired,
@@ -172,69 +190,3 @@ ProfileTopSection.propTypes = {
 		location: PropTypes.string.isRequired,
 	}).isRequired,
 };
-
-// {user: {…}, token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhb…M4OH0.CH_3wuaBPhajIqA7YTfBBiaXVYe7MnyXDA6j6Zk97mU', isAuth: false, loading: false}
-// isAuth
-// :
-// false
-// loading
-// :
-// false
-// token
-// :
-// "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbWFyYXBlYWNlQGdtYWlsLmNvbSIsImV4cCI6MTY3MDE2NDM4OH0.CH_3wuaBPhajIqA7YTfBBiaXVYe7MnyXDA6j6Zk97mU"
-// user
-// :
-// email
-// :
-// "amarapeace@gmail.com"
-// userName
-// :
-// "Amarapeace"
-// user_id
-// :
-// 17
-// wallet
-// :
-// balance
-// :
-// 1000
-// created_at
-// :
-// "2022-12-03T14:52:18.863251"
-// deposits_made
-// :
-// 0
-// id
-// :
-// "38725e21-64ad-494b-ad04-96e70fa31606"
-// spendings
-// :
-// 0
-// user_id
-// :
-// 17
-
-// {
-//   "success": true,
-//   "data": {
-//     "user_id": 17,
-//     "username": "Amarapeace",
-//     "first_name": " ",
-//     "last_name": " ",
-//     "email": "amarapeace@gmail.com",
-//     "description": " ",
-//     "phone_number": " ",
-//     "work_experience": " ",
-//     "position": " ",
-//     "stack": " ",
-//     "links": [
-//       ""
-//     ],
-//     "role": null,
-//     "image_url": " ",
-//     "location": " ",
-//     "is_admin": false,
-//     "account_balance": 1000
-//   }
-// }

--- a/src/components/Section1/index.jsx
+++ b/src/components/Section1/index.jsx
@@ -27,7 +27,7 @@ function ProfileTopSection() {
 			try {
 				setIsLoading(true);
 				const data = await axios.get(
-					`https://pacific-peak-54505.herokuapp.com/users/${user}`,
+					`https://api.devask.hng.tech/users/${user}`,
 					{
 						headers: {
 							Authorization: `Bearer ${state.token}`,
@@ -47,7 +47,7 @@ function ProfileTopSection() {
 			try {
 				setIsLoading(true);
 				const res = await axios.get(
-					`https://pacific-peak-54505.herokuapp.com/following/followers/${state.user.userName}`,
+					`https://api.devask.hng.tech/following/followers/${state.user.userName}`,
 					{
 						headers: {
 							Authorization: `Bearer ${state.token}`,

--- a/src/pages/Profile/AskCards.jsx
+++ b/src/pages/Profile/AskCards.jsx
@@ -10,14 +10,11 @@ import dollarCircle from '../../assets/dashboard-images/dollarCircle.webp';
 
 const token = localStorage.getItem('token');
 async function getUser() {
-	const response = await axios.get(
-		`https://pacific-peak-54505.herokuapp.com/users/`,
-		{
-			headers: {
-				Authorization: `Bearer ${token}`,
-			},
-		}
-	);
+	const response = await axios.get(`https://api.devask.hng.tech/users/`, {
+		headers: {
+			Authorization: `Bearer ${token}`,
+		},
+	});
 	return response.data.data;
 }
 function AskCards() {
@@ -34,7 +31,7 @@ function AskCards() {
 	useEffect(() => {
 		(async function getData() {
 			const userIdResponse = await axios.get(
-				`https://pacific-peak-54505.herokuapp.com/users/${thisuser}`,
+				`https://https://api.devask.hng.tech/users/${thisuser}`,
 				{
 					headers: {
 						Authorization: `Bearer ${token}`,
@@ -43,7 +40,7 @@ function AskCards() {
 			);
 			const userIdData = await userIdResponse.data.data.user_id;
 			const response = await axios.get(
-				`https://pacific-peak-54505.herokuapp.com/questions/${userIdData}/user`,
+				`https://https://api.devask.hng.tech/questions/${userIdData}/user`,
 				{
 					headers: {
 						Authorization: `Bearer ${token}`,

--- a/src/pages/Profile/AskCards.jsx
+++ b/src/pages/Profile/AskCards.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import styles from './AskCards.module.css';
-
 import options from '../../assets/dashboard-images/options.webp';
 import message from '../../assets/dashboard-images/message.webp';
 import heartBold from '../../assets/dashboard-images/heartBold.webp';
@@ -10,7 +9,6 @@ import share from '../../assets/dashboard-images/share.webp';
 import dollarCircle from '../../assets/dashboard-images/dollarCircle.webp';
 
 const token = localStorage.getItem('token');
-
 async function getUser() {
 	const response = await axios.get(
 		`https://pacific-peak-54505.herokuapp.com/users/`,
@@ -22,47 +20,50 @@ async function getUser() {
 	);
 	return response.data.data;
 }
-
 function AskCards() {
+	const { pathname } = useLocation();
+	const thisuser = pathname.slice(9);
 	const formatDate = (date) =>
 		new Intl.DateTimeFormat(navigator.language, {
 			day: '2-digit',
 			month: 'long',
 		}).format(new Date(date));
-
 	const [questions, setQuestions] = useState([]);
 	const [users, setUsers] = useState([]);
 	const findUser = (id) => users.find((user) => user.user_id === id);
-
 	useEffect(() => {
 		(async function getData() {
-			const response = await axios.get(
-				'https://pacific-peak-54505.herokuapp.com/questions/',
+			const userIdResponse = await axios.get(
+				`https://pacific-peak-54505.herokuapp.com/users/${thisuser}`,
 				{
 					headers: {
 						Authorization: `Bearer ${token}`,
 					},
 				}
 			);
-
+			const userIdData = await userIdResponse.data.data.user_id;
+			const response = await axios.get(
+				`https://pacific-peak-54505.herokuapp.com/questions/${userIdData}/user`,
+				{
+					headers: {
+						Authorization: `Bearer ${token}`,
+					},
+				}
+			);
 			const fetchedQuestions = await response.data.data;
-
 			setQuestions(fetchedQuestions);
-
 			setUsers(await getUser());
 		})();
 	}, []);
-
 	const askCard = questions.map((question) => (
 		<div className={styles.cardContainer} key={question.question_id}>
 			<Link to={`/profile/${question.owner_id}`}>
 				<img
-					src="https://www.dropbox.com/s/bigbspbwyadigzj/Ellipse%201%20%281%29.svg?raw=1"
+					src="https://www.pngitem.com/pimgs/m/581-5813504_avatar-dummy-png-transparent-png.png"
 					alt=""
 					className={styles.profilePicture}
 				/>
 			</Link>
-
 			<div>
 				<section className={styles.cardHeader}>
 					<div className={styles.userInfo}>
@@ -74,12 +75,10 @@ function AskCards() {
 								{findUser(question.owner_id)?.username}
 							</h5>
 						</Link>
-
 						<p className={styles.time}>{formatDate(question.created_at)}</p>
 					</div>
 					<img src={options} alt="" className={styles.options} />
 				</section>
-
 				<Link
 					to={`/dashboard/questions/${question.question_id}`}
 					style={{ textDecoration: 'none' }}
@@ -89,7 +88,6 @@ function AskCards() {
 						{question.content}
 					</p>
 				</Link>
-
 				<section className={styles.cardFooter}>
 					<div className={styles.icons}>
 						<span className={styles.viewReplies}>
@@ -108,100 +106,6 @@ function AskCards() {
 			</div>
 		</div>
 	));
-
 	return <div className={styles.cards}>{askCard}</div>;
 }
-
 export default AskCards;
-
-// import React, {useContext} from 'react';
-// import { Link } from 'react-router-dom';
-// import styles from './AskCards.module.css';
-// import { AppContext } from '../../store/AppContext';
-
-// import testQuestions from '../../utils/testQuestions.json';
-// import options from '../../assets/dashboard-images/options.webp';
-// import message from '../../assets/dashboard-images/message.webp';
-// import heartBold from '../../assets/dashboard-images/heartBold.webp';
-// import share from '../../assets/dashboard-images/share.webp';
-// import dollarCircle from '../../assets/dashboard-images/dollarCircle.webp';
-
-// function AskCards() {
-
-// 	const {
-// 		state: { user: userInformation },
-// 	} = useContext(AppContext);
-// 	console.log(userInformation);
-
-// 	const askCard = testQuestions.map((question) => (
-// 		<div className={styles.cardContainer} key={question.id}>
-// 			<Link to={`/profile/${question.id}`}>
-// 				<img
-// 					src={`${question.user.profile_image_url_https}`}
-// 					alt=""
-// 					className={styles.profilePicture}
-// 				/>
-// 			</Link>
-
-// 			<div>
-// 				<section className={styles.cardHeader}>
-// 					<div className={styles.userInfo}>
-// 						<Link
-// 							to={`/profile/${question.id}`}
-// 							style={{ display: 'flex', textDecoration: 'none' }}
-// 						>
-// 							<h5 className={styles.askName}>{question.user.name}</h5>
-// 							<p className={styles.userName}>{question.user.screen_name}</p>
-// 						</Link>
-
-// 						<p className={styles.time}>36 secs</p>
-// 					</div>
-// 					<img src={options} alt="" className={styles.options} />
-// 				</section>
-
-// 				<Link
-// 					to={`/dashboard/questions/${question.id}`}
-// 					style={{ textDecoration: 'none' }}
-// 				>
-// 					<h4 className={styles.title}> {question.title}</h4>
-// 					<p className={styles.reply} style={{ lineHeight: '1.8' }}>
-// 						{question.detail}
-// 					</p>
-// 				</Link>
-
-// 				<div className={styles.tagWrapper}>
-// 					{question.tags.map((tag) => (
-// 						<Link
-// 							to="/tags-page"
-// 							style={{ textDecoration: 'none', display: 'flex' }}
-// 						>
-// 							<p className={styles.tag} key={tag}>
-// 								{tag}
-// 							</p>
-// 						</Link>
-// 					))}
-// 				</div>
-
-// 				<section className={styles.cardFooter}>
-// 					<div className={styles.icons}>
-// 						<span className={styles.viewReplies}>
-// 							<img src={message} alt="" /> 17
-// 						</span>
-// 						<span className={styles.likes}>
-// 							<img src={heartBold} alt="" /> 30
-// 						</span>
-// 						<img src={share} alt="" className={styles.share} />
-// 					</div>
-// 					<span className={styles.reward}>
-// 						<img src={dollarCircle} alt="" /> {userInformation?.wallet.balance}
-// 						eth
-// 					</span>
-// 				</section>
-// 			</div>
-// 		</div>
-// 	));
-
-// 	return <div className={styles.cards}>{askCard}</div>;
-// }
-
-// export default AskCards;


### PR DESCRIPTION
### Fixes Issue
My PR implements the 'Profile page for the owner and for a guest user'

### Changes proposed
The owner's profile top section should contain details about the owner. These details include the information about the owner obtained during sign-up as well as those obtained when the owner updates his/her profile through the 'edit profile' button right there on the page or through the 'edit profile' section of the 'settings' page.
For a guest user, a 'follow' button is provided as he/she would not be able to edit.
The rest of the page contains questions, replies, likes and rewards specific to the account owner.

### What were you told to do?
I was told to get the account owner's details to reflect on the profile page as well as the questions, replies, likes and rewards pertaining to the user.

### What did you do?
I developed the 'profile' page with its features and functionalities for an account owner and for a guest user.

### Check List (Check all the applicable boxes)
☑︎ My code follows the code style of this project.
☑︎ This PR does not contain plagiarized content.
☑︎ The title and description of the PR are clear and explain the approach.
☑︎ I am making a pull request against the dev branch (left side).
☑︎ My commit messages styles match our requested structure.
☑︎ My code additions will fail neither code linting checks nor unit tests.
☑︎ I am only making changes to the files I was requested to.

### Screenshots
For account owner
https://user-images.githubusercontent.com/101415207/205487829-dfb85ea9-d6a8-4331-8d9c-b8f7ea698c54.png

### For a guest user
https://user-images.githubusercontent.com/101415207/205488138-97e6bd2b-f73a-4b0b-8743-ab01fdb00ae4.png