### PR TITLE
fix:Styled the text editor and added dangerouslySetInnerHTML

### DIFF
--- a/src/components/AskCards/AskCards.jsx
+++ b/src/components/AskCards/AskCards.jsx
@@ -99,9 +99,7 @@ function AskCards({ onClose, show, hide, showShare }) {
 
 				<div>
 					<h4 className={styles.title}>{question.title}</h4>
-					<p className={styles.reply} style={{ lineHeight: '1.8' }}>
-						{question.content}
-					</p>
+					<p className={styles.reply} style={{ lineHeight: '1.8' }} dangerouslySetInnerHTML={{__html: question.content}} />
 				</div>
 
 				<section className={styles.cardFooter}>

--- a/src/components/Editor/Editor.jsx
+++ b/src/components/Editor/Editor.jsx
@@ -42,9 +42,7 @@ function Editor() {
 
 	return (
 		<div className={styles.editorContainer}>
-			<div className={styles.questionArea}>
 				<img src={profilePicture} alt="" className={styles.profilePicture} />
-
 				<ReactQuill
 					className={styles.writeQuestion}
 					placeholder="Start a discussion"
@@ -55,12 +53,9 @@ function Editor() {
 					onChange={handleQuestion}
 					value={question.text}
 				/>
-			</div>
-			<div className={styles.editorFooter}>
-				<button type="button" onClick={submitHandler}>
+				<button className={styles.editorFooter} type="button" onClick={submitHandler}>
 					Post
 				</button>
-			</div>
 		</div>
 	);
 }

--- a/src/components/Editor/Editor.module.css
+++ b/src/components/Editor/Editor.module.css
@@ -1,5 +1,5 @@
 .editorContainer {
-	background-color: #ffffff;
+	background-color: #f7f2f2;
 	border: 1px solid #ececfb;
 	border-radius: 8px;
 	display: flex;
@@ -10,32 +10,16 @@
 	width: 60%;
 }
 
-.questionArea {
-	display: flex;
-	gap: 1rem;
-	border-bottom: 1px solid #d6d6d6;
-	font-size: 16px;
-}
-
-.questionArea textarea {
-	padding: 0em 1em;
-}
-
 .profilePicture {
 	width: 60px;
 	height: 60px;
 }
 
 .writeQuestion {
-	outline: none;
-	border: none;
-	resize: none;
-	overflow: hidden;
 	width: 100%;
-	margin: 0.5em 0;
-
 	font-weight: 400;
 	font-size: 16px;
+	background-color: #ffffff;
 }
 
 .writeQuestion::placeholder {
@@ -44,23 +28,12 @@
 	color: #8f8f8f;
 }
 
+
 .editorFooter {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-}
-
-/* .editorFooter > div {
-	display: flex;
-	gap: 1.5rem;
-} */
-
-
-
-.editorFooter > button {
 	font-family: 'Rubik', sans-serif;
 	font-weight: 400;
 	font-size: 14px;
+	width: 5rem;
 	background-color: #4343de;
 	color: #fefefe;
 	border: 1px solid #4343de;
@@ -87,17 +60,7 @@
 		font-size: 12px;
 	}
 
-	.editorFooter > div {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-	.editorIcons {
-		width: 0.5rem;
-		height: 0.5rem;
-	}
-
-	.editorFooter > button {
+	.editorFooter{
 		font-size: 10px;
 	}
 }


### PR DESCRIPTION
FE-95

My PR Fixes FE-95/INPUT TEXT/CODE FORMATTING

### Changes proposed
What were you told to do?
I was told to implement rich code editor on every page requiring it on devask

### What did you do?
I styled the text editor Editor.jsx component within the dashboard page and added dagerouslySetInnerHTML in the AskCards.jsx so that the contents are displayed the way the user specified with the exception of the extra sytax added by the editor.

### Check List (Check all the applicable boxes)
 
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the dev branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.


![Screenshot 2022-12-06 at 20 12 49](https://user-images.githubusercontent.com/102606024/206001267-1f4a9fa9-cb95-46ac-a188-476671de833d.png)
